### PR TITLE
Some minor changes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,5 @@
 
 import express from 'express';
-import bodyParser from 'body-parser';
 import mongoose from 'mongoose';
 import cors from 'cors';
 
@@ -8,8 +7,8 @@ import postRoutes from './routes/posts.js';
 
 const app = express();
 
-app.use(bodyParser.json({ limit: '30mb', extended: true }))
-app.use(bodyParser.urlencoded({ limit: '30mb', extended: true }))
+app.use(express.json({ limit: '30mb', extended: true }))
+app.use(express.urlencoded({ limit: '30mb', extended: true }))
 app.use(cors());
 
 app.use('/posts', postRoutes);


### PR DESCRIPTION
On line 10 app.use(bodyparser.json({ limit: '30mb', extended: true })) changed to app.use(express.json({ limit: '30mb', extended: true }))
On line 11 app.use(bodyparser.urlencoded({ limit: '30mb', extended: true })) changed to app.use(express.urlencoded({ limit: '30mb', extended: true }))
bodyparser is deprecated now so we can use express.json and express.unrlencoded in our code