### PR TITLE
Update posts.js reduces to fix unnamed export

### DIFF
--- a/client/src/reducers/posts.js
+++ b/client/src/reducers/posts.js
@@ -1,6 +1,6 @@
 import { FETCH_ALL, CREATE, UPDATE, DELETE, LIKE } from '../constants/actionTypes';
 
-export default (posts = [], action) => {
+const posts = (posts = [], action) => {
   switch (action.type) {
     case FETCH_ALL:
       return action.payload;
@@ -16,4 +16,6 @@ export default (posts = [], action) => {
       return posts;
   }
 };
+
+export default posts;
 


### PR DESCRIPTION
Without this fix of naming the variable posts, there is a warning that appears in the console.