### PR TITLE
Fixed warning message in posts.js inside reducers

### DIFF
--- a/client/src/reducers/posts.js
+++ b/client/src/reducers/posts.js
@@ -1,6 +1,6 @@
 import { FETCH_ALL, CREATE, UPDATE, DELETE, LIKE } from '../constants/actionTypes';
 
-export default (posts = [], action) => {
+const reducers = (posts = [], action) => {
   switch (action.type) {
     case FETCH_ALL:
       return action.payload;
@@ -17,3 +17,4 @@ export default (posts = [], action) => {
   }
 };
 
+export default reducers;


### PR DESCRIPTION
This will fix the warning message of "Assign arrow function to a variable before exporting as module default" for the posts.js file inside the reducers folder of our client side.