### PR TITLE
Preventing seeing no posts when clicking on the "Search" button while search inputs are empty

### DIFF
--- a/client/src/components/Home/Home.js
+++ b/client/src/components/Home/Home.js
@@ -27,7 +27,7 @@ const Home = () => {
   const history = useHistory();
 
   const searchPost = () => {
-    if (search.trim() || tags) {
+    if (search.trim().length || tags.length) {
       dispatch(getPostsBySearch({ search, tags: tags.join(',') }));
       history.push(`/posts/search?searchQuery=${search || 'none'}&tags=${tags.join(',')}`);
     } else {


### PR DESCRIPTION
I realized that when you click on the "Search" button and both "tags" & "search" inputs are empty, then it's going to show you the loading icon and return an empty array which is not the expected output.
This means it's still going to run the `if` block of code (if you pay attention to the url) while the `else` block must be executed instead of that.

It means we should change our conditions and just add `length` at the end of the `search.trim()` & `tags` so as to count the number of items in our array.
This will produce the ideal and expected output and it will run the `else` block while we have written nothing in the search inputs and have also clicked on the search button instead of seeing no posts on the screen. So, it means it's going to redirect the user to the home page (`history.push('/')`) if we only click on the "Search" button without writing anything in its inputs.