### PR TITLE
fix runtime-error

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,10 +20,13 @@
     "redux-thunk": "^2.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start-legacy": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build-legacy": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "test-legacy": "NODE_OPTIONS=--openssl-legacy-provider react-scripts test"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
fixes: #199
the runtime error on Mac:
Error: Error: error:0308010C:digital envelope routines::unsupported

To resolve this issue, I updated the `package.json` file to include the following line:
"start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start"

This change ensures compatibility by utilizing the legacy OpenSSL provider during the start script execution.